### PR TITLE
Add support of value cast into interface value type

### DIFF
--- a/order_dao_example_test.go
+++ b/order_dao_example_test.go
@@ -1,6 +1,7 @@
 package pgxpoolmock_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/driftprogramming/pgxpoolmock"
@@ -30,4 +31,29 @@ func TestName(t *testing.T) {
 	assert.NotNil(t, actualOrder)
 	assert.Equal(t, 100, actualOrder.ID)
 	assert.Equal(t, 100000.9, actualOrder.Price)
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// given
+	mockPool := pgxpoolmock.NewMockPgxPool(ctrl)
+	columns := []string{"id", "price"}
+	pgxRows := pgxpoolmock.NewRows(columns).AddRow(100, 100000.9).ToPgxRows()
+	assert.NotEqual(t, "with empty rows", fmt.Sprintf("%s", pgxRows))
+
+	mockPool.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgxRows, nil)
+	orderDao := testdata.OrderDAO{
+		Pool: mockPool,
+	}
+
+	// when
+	actualOrder := orderDao.GetOrderMapByID(1)
+
+	// then
+	assert.NotNil(t, actualOrder)
+	assert.Equal(t, 100, actualOrder["ID"])
+	assert.Equal(t, 100000.9, actualOrder["Price"])
 }

--- a/rows.go
+++ b/rows.go
@@ -64,7 +64,7 @@ func (rs *rowSets) Values() ([]interface{}, error) {
 func (rs *rowSets) Scan(dest ...interface{}) error {
 	r := rs.sets[rs.pos]
 	if len(dest) != len(r.defs) {
-		return fmt.Errorf("Incorrect argument number %d for columns %d", len(dest), len(r.defs))
+		return fmt.Errorf("incorrect argument number %d for columns %d", len(dest), len(r.defs))
 	}
 	for i, col := range r.rows[r.pos-1] {
 		if dest[i] == nil {
@@ -73,22 +73,24 @@ func (rs *rowSets) Scan(dest ...interface{}) error {
 		}
 		destVal := reflect.ValueOf(dest[i])
 		if destVal.Kind() != reflect.Ptr {
-			return fmt.Errorf("Destination argument must be a pointer for column %s", r.defs[i].Name)
+			return fmt.Errorf("destination argument must be a pointer for column %s", r.defs[i].Name)
 		}
 		if col == nil {
 			dest[i] = nil
 			continue
 		}
 		val := reflect.ValueOf(col)
-		if destVal.Elem().Kind() == val.Kind() {
+
+		destKind := destVal.Elem().Kind()
+		if destKind == val.Kind() || destKind == reflect.Interface {
 			if destElem := destVal.Elem(); destElem.CanSet() {
 				destElem.Set(val)
 			} else {
-				return fmt.Errorf("Cannot set destination value for column %s", string(r.defs[i].Name))
+				return fmt.Errorf("cannot set destination value for column %s", string(r.defs[i].Name))
 			}
 		} else {
-			return fmt.Errorf("Destination kind '%v' not supported for value kind '%v' of column '%s'",
-				destVal.Elem().Kind(), val.Kind(), string(r.defs[i].Name))
+			return fmt.Errorf("destination kind '%v' not supported for value kind '%v' of column '%s'",
+				destKind, val.Kind(), string(r.defs[i].Name))
 		}
 	}
 	return r.nextErr[r.pos-1]

--- a/testdata/order.go
+++ b/testdata/order.go
@@ -25,3 +25,18 @@ func (dao *OrderDAO) GetOrderByID(id int) *Order {
 
 	return nil
 }
+
+func (dao *OrderDAO) GetOrderMapByID(id int) map[string]interface{} {
+	rows, _ := dao.Pool.Query(context.Background(), "SELECT ID,Price FROM order WHERE ID =$1", id)
+	for rows.Next() {
+		var id, price interface{}
+		rows.Scan(&id, &price)
+		order := map[string]interface{}{
+			"ID":    id,
+			"Price": price,
+		}
+		return order
+	}
+
+	return nil
+}


### PR DESCRIPTION
In case of interface type of the field need to map any type from DB response.
It works in the original PGX driver so need to support for proper unit testing.

For example:
This type of code is properly works with real pgx driver.
```go
type Record map[string]interface{}

func (b *Bind) list(ctx context.Context, ectx keypattern.ExecContext) ([]Record, error) {
	res := make([]Record, 0, 10)
	err := pgxscan.Select(ctx, b.conn, &res, b.listQuery.String(), b.listQuery.args(ectx)...)
	return res, err
}
```

The pool request makes possible to work such kind of tests
```go
	t.Run("select list", func(t *testing.T) {
		columns := []string{"id", "username"}
		pgxRows := pgxpoolmock.NewRows(columns).
			AddRow(1, "testuser1").
			AddRow(2, "testuser2").ToPgxRows()
		mockPool.EXPECT().
			Query(gomock.Any(), gomock.Any()).
			Return(pgxRows, nil)
		res, err := bind.list(ctx, ectx)
		if assert.NoError(t, err) {
			assert.Equal(t, 2, len(res))
			assert.Equal(t, 1, res[0]["id"])
			assert.Equal(t, 2, res[1]["id"])
		}
	})
```